### PR TITLE
initial test framework, gulpfile, updated package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,49 @@
+var gulp = require('gulp');
+var jshint = require('gulp-jshint');
+var mocha = require('gulp-mocha');
+var appFiles = ['index.js', 'lib/**/*.js', 'bin/**/*.js'];
+var testFiles = ['test/**/*.js'];
+
+gulp.task('jshint:test', function() {
+  return gulp.src(testFiles)
+    .pipe(jshint({
+        node: true,
+        globals: {
+            describe: true,
+            it: true,
+            before: true,
+            after: true
+        }
+    }))
+    .pipe(jshint.reporter('default'));
+});
+
+gulp.task('jshint:app', function() {
+  return gulp.src(appFiles)
+    .pipe(jshint({
+        node: true,
+        globals: {
+            describe: true,
+            it: true,
+            before: true,
+            after: true
+        }
+    }))
+    .pipe(jshint.reporter('default'));
+});
+
+gulp.task('mocha', function(){
+  return gulp.src(testFiles)
+      .pipe(jshint({
+        node: true,
+        globals: {
+          describe: true,
+          it: true
+      }
+    }))
+    .pipe(mocha({reporter: 'spec'}));
+});
+
+
+gulp.task('jshint', ['jshint:test', 'jshint:app']);
+gulp.task('default', ['jshint', 'mocha']);

--- a/package.json
+++ b/package.json
@@ -22,5 +22,13 @@
   "bugs": {
     "url": "https://github.com/timmydoza/glurp/issues"
   },
-  "homepage": "https://github.com/timmydoza/glurp#readme"
+  "homepage": "https://github.com/timmydoza/glurp#readme",
+  "devDependencies": {
+    "chai": "^3.4.0",
+    "chai-http": "^1.0.0",
+    "gulp": "^3.9.0",
+    "gulp-jshint": "^1.12.0",
+    "gulp-mocha": "^2.1.3",
+    "mocha": "^2.3.3"
+  }
 }


### PR DESCRIPTION
default gulp will run js-hint.  No actual mocha tests implemented yet.

run npm install to install mocha, gulp, gulp-jshint, et al after merging the new package.json file.
